### PR TITLE
AVX-53903/AVX-53901: TF apply failures reported as Terraform Failures and error reported to testrail report when testcaseid mismatch

### DIFF
--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -14,44 +14,49 @@ TESTRAIL_TEST_STATUS = {
     "untested": 3,
     "retest": 4,
     "failed": 5,
+    "deferred": 6,
+    "NA": 7,
+    "terraformerror": 8,
 }
 
+# Update the mapping for pytest outcomes
 PYTEST_TO_TESTRAIL_STATUS = {
     "passed": TESTRAIL_TEST_STATUS["passed"],
     "failed": TESTRAIL_TEST_STATUS["failed"],
     "skipped": TESTRAIL_TEST_STATUS["blocked"],
+    "deferred": TESTRAIL_TEST_STATUS["deferred"],
+    "NA": TESTRAIL_TEST_STATUS["NA"],
+    "terraformerror": TESTRAIL_TEST_STATUS["terraformerror"],
 }
 
-DT_FORMAT = "%d-%m-%Y %H:%M:%S"
+DT_FORMAT = '%d-%m-%Y %H:%M:%S'
 
-TESTRAIL_PREFIX = "testrail"
-TESTRAIL_DEFECTS_PREFIX = "testrail_defects"
-ADD_RESULTS_URL = "add_results_for_cases/{}"
-ADD_TESTRUN_URL = "add_run/{}"
-CLOSE_TESTRUN_URL = "close_run/{}"
-CLOSE_TESTPLAN_URL = "close_plan/{}"
-GET_TESTRUN_URL = "get_run/{}"
-GET_TESTPLAN_URL = "get_plan/{}"
-GET_TESTS_URL = "get_tests/{}"
+TESTRAIL_PREFIX = 'testrail'
+TESTRAIL_DEFECTS_PREFIX = 'testrail_defects'
+ADD_RESULTS_URL = 'add_results_for_cases/{}'
+ADD_TESTRUN_URL = 'add_run/{}'
+CLOSE_TESTRUN_URL = 'close_run/{}'
+CLOSE_TESTPLAN_URL = 'close_plan/{}'
+GET_TESTRUN_URL = 'get_run/{}'
+GET_TESTPLAN_URL = 'get_plan/{}'
+GET_TESTS_URL = 'get_tests/{}'
 
 COMMENT_SIZE_LIMIT = 4000
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-
 class DeprecatedTestDecorator(DeprecationWarning):
     pass
 
 
-warnings.simplefilter(action="once", category=DeprecatedTestDecorator, lineno=0)
+warnings.simplefilter(action='once', category=DeprecatedTestDecorator, lineno=0)
 
 
 class pytestrail(object):
-    """
+    '''
     An alternative to using the testrail function as a decorator for test cases, since py.test may confuse it as a test
     function since it has the 'test' prefix
-    """
+    '''
 
     @staticmethod
     def case(*ids):
@@ -67,12 +72,12 @@ class pytestrail(object):
     @staticmethod
     def defect(*defect_ids):
         """
-        Decorator to mark defects with defect ids.
+                Decorator to mark defects with defect ids.
 
-        ie. @pytestrail.defect('PF-513', 'BR-3255')
+                ie. @pytestrail.defect('PF-513', 'BR-3255')
 
-        :return pytest.mark:
-        """
+                :return pytest.mark:
+                """
         return pytest.mark.testrail_defects(defect_ids=defect_ids)
 
 
@@ -84,10 +89,8 @@ def testrail(*ids):
 
     :return pytest.mark:
     """
-    deprecation_msg = (
-        "pytest_testrail: the @testrail decorator is deprecated and will be removed. Please use the "
-        "@pytestrail.case decorator instead."
-    )
+    deprecation_msg = ('pytest_testrail: the @testrail decorator is deprecated and will be removed. Please use the '
+                       '@pytestrail.case decorator instead.')
     warnings.warn(deprecation_msg, DeprecatedTestDecorator)
     return pytestrail.case(*ids)
 
@@ -105,7 +108,7 @@ def get_test_outcome(outcome):
 def testrun_name():
     """Returns testrun name with timestamp"""
     now = datetime.utcnow()
-    return "Automated Run {}".format(now.strftime(DT_FORMAT))
+    return 'Automated Run {}'.format(now.strftime(DT_FORMAT))
 
 
 def clean_test_ids(test_ids):
@@ -115,23 +118,17 @@ def clean_test_ids(test_ids):
     :param list test_ids: list of test_ids.
     :return list ints: contains list of test_ids as ints.
     """
-    return [
-        int(re.search("(?P<test_id>[0-9]+$)", test_id).groupdict().get("test_id"))
-        for test_id in test_ids
-    ]
+    return [int(re.search('(?P<test_id>[0-9]+$)', test_id).groupdict().get('test_id')) for test_id in test_ids]
 
 
 def clean_test_defects(defect_ids):
     """
-    Clean pytest marker containing testrail defects ids.
+        Clean pytest marker containing testrail defects ids.
 
-    :param list defect_ids: list of defect_ids.
-    :return list ints: contains list of defect_ids as ints.
-    """
-    return [
-        (re.search("(?P<defect_id>.*)", defect_id).groupdict().get("defect_id"))
-        for defect_id in defect_ids
-    ]
+        :param list defect_ids: list of defect_ids.
+        :return list ints: contains list of defect_ids as ints.
+        """
+    return [(re.search('(?P<defect_id>.*)', defect_id).groupdict().get('defect_id')) for defect_id in defect_ids]
 
 
 def get_testrail_keys(items):
@@ -143,33 +140,17 @@ def get_testrail_keys(items):
                 (
                     item,
                     clean_test_ids(
-                        item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get("ids")
-                    ),
+                        item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get('ids')
+                    )
                 )
             )
     return testcaseids
 
 
 class PyTestRailPlugin(object):
-    def __init__(
-        self,
-        client,
-        assign_user_id,
-        project_id,
-        suite_id,
-        include_all,
-        cert_check,
-        tr_name,
-        tr_description="",
-        run_id=0,
-        plan_id=0,
-        version="",
-        close_on_complete=False,
-        publish_blocked=True,
-        skip_missing=False,
-        milestone_id=None,
-        custom_comment=None,
-    ):
+    def __init__(self, client, assign_user_id, project_id, suite_id, include_all, cert_check, tr_name,
+                 tr_description='', run_id=0, plan_id=0, version='', close_on_complete=False,
+                 publish_blocked=True, skip_missing=False, milestone_id=None, custom_comment=None):
         self.assign_user_id = assign_user_id
         self.cert_check = cert_check
         self.client = client
@@ -191,14 +172,14 @@ class PyTestRailPlugin(object):
     # pytest hooks
 
     def pytest_report_header(self, config, startdir):
-        """Add extra-info in header"""
-        message = "pytest-testrail: "
+        """ Add extra-info in header """
+        message = 'pytest-testrail: '
         if self.testplan_id:
-            message += "existing testplan #{} selected".format(self.testplan_id)
+            message += 'existing testplan #{} selected'.format(self.testplan_id)
         elif self.testrun_id:
-            message += "existing testrun #{} selected".format(self.testrun_id)
+            message += 'existing testrun #{} selected'.format(self.testrun_id)
         else:
-            message += "a new testrun will be created"
+            message += 'a new testrun will be created'
         return message
 
     @pytest.hookimpl(trylast=True)
@@ -212,11 +193,11 @@ class PyTestRailPlugin(object):
             self.testplan_id = 0
             if self.skip_missing:
                 tests_list = [
-                    test.get("case_id") for test in self.get_tests(self.testrun_id)
+                    test.get('case_id') for test in self.get_tests(self.testrun_id)
                 ]
                 for item, case_id in items_with_tr_keys:
                     if not set(case_id).intersection(set(tests_list)):
-                        mark = pytest.mark.skip("Test is not present in testrun.")
+                        mark = pytest.mark.skip('Test is not present in testrun.')
                         item.add_marker(mark)
         else:
             if self.testrun_name is None:
@@ -230,29 +211,27 @@ class PyTestRailPlugin(object):
                 self.testrun_name,
                 tr_keys,
                 self.milestone_id,
-                self.testrun_description,
+                self.testrun_description
             )
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True)
     def pytest_runtest_makereport(self, item, call):
-        """Collect result and associated testcases (TestRail) of an execution"""
+        """ Collect result and associated testcases (TestRail) of an execution """
         outcome = yield
         rep = outcome.get_result()
         defectids = None
-        if "callspec" in dir(item):
+        if 'callspec' in dir(item):
             test_parametrize = item.callspec.params
         else:
             test_parametrize = None
         comment = rep.longrepr
         if item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX):
-            defectids = item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX).kwargs.get(
-                "defect_ids"
-            )
+            defectids = item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX).kwargs.get('defect_ids')
         if item.get_closest_marker(TESTRAIL_PREFIX):
-            testcaseids = item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get("ids")
-            if rep.when in ["setup", "call"] and testcaseids:
+            testcaseids = item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get('ids')
+            if rep.when in ['setup', 'call'] and testcaseids:
                 # Check if the test case has already been processed
-                if not getattr(item, "testrail_processed", False):
+                if not getattr(item, 'testrail_processed', False):
                     # Mark the test case as processed
                     item.testrail_processed = True
                     if defectids:
@@ -261,11 +240,8 @@ class PyTestRailPlugin(object):
                             get_test_outcome(outcome.get_result().outcome),
                             comment=comment,
                             duration=rep.duration,
-                            defects=str(clean_test_defects(defectids))
-                            .replace("[", "")
-                            .replace("]", "")
-                            .replace("'", ""),
-                            test_parametrize=test_parametrize,
+                            defects=str(clean_test_defects(defectids)).replace('[', '').replace(']', '').replace("'", ''),
+                            test_parametrize=test_parametrize
                         )
                     else:
                         self.add_result(
@@ -273,104 +249,79 @@ class PyTestRailPlugin(object):
                             get_test_outcome(outcome.get_result().outcome),
                             comment=comment,
                             duration=rep.duration,
-                            test_parametrize=test_parametrize,
+                            test_parametrize=test_parametrize
                         )
 
     def pytest_sessionfinish(self, session, exitstatus):
         """Publish results in TestRail"""
-        print("[{}] Start publishing".format(TESTRAIL_PREFIX))
-        if self.results:
-            tests_list = [str(result["case_id"]) for result in self.results]
-            print(
-                "[{}] Testcases to publish: {}".format(
-                    TESTRAIL_PREFIX, ", ".join(tests_list)
-                )
-            )
-            if self.testrun_id:
-                error = self.add_results(self.testrun_id)  # Check for errors
-                if (
-                    error
-                    and "results cannot be empty but no valid tests or cases found"
-                    in error
-                ):
-                    print(
-                        "[{}] No valid test results to publish".format(TESTRAIL_PREFIX)
-                    )
-                    raise Exception("No valid test results to publish in TestRail")
-                elif error:
-                    error_message_parts = error.split(")")
-                    invalid_test_ids = [
-                        part.split("case ")[1].split(" ")[0]
-                        for part in error_message_parts
-                        if "case" in part
-                    ]
-                    valid_results = [
-                        result
-                        for result in self.results
-                        if result["case_id"] not in invalid_test_ids
-                    ]
-                    for invalid_test_id in invalid_test_ids:
-                        self.add_error_results(
-                            self.testrun_id, [invalid_test_id], error
-                        )
-            elif self.testplan_id:
-                testruns = self.get_available_testruns(self.testplan_id)
-                print(
-                    "[{}] Testruns to update: {}".format(
-                        TESTRAIL_PREFIX, ", ".join([str(elt) for elt in testruns])
-                    )
-                )
-                for testrun_id in testruns:
-                    error = self.add_results(testrun_id)  # Check for errors
-                    if (
-                        error
-                        and "results cannot be empty but no valid tests or cases found"
-                        in error
-                    ):
-                        print(
-                            "[{}] No valid test results to publish for testrun {}".format(
-                                TESTRAIL_PREFIX, testrun_id
-                            )
-                        )
-                        raise Exception("No valid test results to publish in TestRail")
-                    elif error:
-                        error_message_parts = error.split(")")
-                        invalid_test_ids = [
-                            part.split("case ")[1].split(" ")[0]
-                            for part in error_message_parts
-                            if "case" in part
-                        ]
-                        valid_results = [
-                            result
-                            for result in self.results
-                            if result["case_id"] not in invalid_test_ids
-                        ]
-                        for invalid_test_id in invalid_test_ids:
-                            self.add_error_results(testrun_id, [invalid_test_id], error)
-            else:
-                print("[{}] No data published".format(TESTRAIL_PREFIX))
+        print('[{}] Start publishing'.format(TESTRAIL_PREFIX))
+        
+        if not self.results:
+            print('[{}] No test results to publish'.format(TESTRAIL_PREFIX))
+            raise Exception('No test results to publish in TestRail')
 
-            if self.close_on_complete and self.testrun_id:
-                self.close_test_run(self.testrun_id)
-            elif self.close_on_complete and self.testplan_id:
-                self.close_test_plan(self.testplan_id)
+        tests_list = [str(result['case_id']) for result in self.results]
+        print('[{}] Testcases to publish: {}'.format(TESTRAIL_PREFIX, ', '.join(tests_list)))
+
+        if self.testrun_id:
+            self.publish_results_for_run(self.testrun_id)
+        elif self.testplan_id:
+            testruns = self.get_available_testruns(self.testplan_id)
+            print('[{}] Testruns to update: {}'.format(TESTRAIL_PREFIX, ', '.join(map(str, testruns))))
+            for testrun_id in testruns:
+                self.publish_results_for_run(testrun_id)
         else:
-            print("[{}] No test results to publish".format(TESTRAIL_PREFIX))
-            # Gracefully handle the scenario where there are no test results to publish
-            raise Exception("No test results to publish in TestRail")
-        print("[{}] End publishing".format(TESTRAIL_PREFIX))
+            print('[{}] No data published'.format(TESTRAIL_PREFIX))
+
+        if self.close_on_complete:
+            if self.testrun_id:
+                self.close_test_run(self.testrun_id)
+            elif self.testplan_id:
+                self.close_test_plan(self.testplan_id)
+
+        print('[{}] End publishing'.format(TESTRAIL_PREFIX))
+
+    def publish_results_for_run(self, testrun_id):
+        """Publish results for a specific test run"""
+        error = self.add_results(testrun_id)
+        if error:
+            terraform_errors = self.extract_terraform_errors(error)
+            if terraform_errors:
+                for test_id, terraform_error in terraform_errors.items():
+                    self.add_terraform_error_results(testrun_id, test_id, terraform_error)
+                print('[{}] Terraform errors successfully reported for testrun {}'.format(TESTRAIL_PREFIX, testrun_id))
+            else:
+                print('[{}] Other errors occurred, reporting them for testrun {}'.format(TESTRAIL_PREFIX, testrun_id))
+                error_message_parts = error.split(')')
+                invalid_test_ids = [part.split('case ')[1].split(' ')[0] for part in error_message_parts if 'case' in part]
+                valid_results = [result for result in self.results if result['case_id'] not in invalid_test_ids]
+                for invalid_test_id in invalid_test_ids:
+                    self.add_error_results(testrun_id, [invalid_test_id], error)
+        else:
+            print('[{}] Test results successfully published for testrun {}'.format(TESTRAIL_PREFIX, testrun_id))
+
+    def extract_terraform_errors(self, error_message):
+        """Extract Terraform errors from the error message"""
+        terraform_errors = {}
+        for match in re.finditer(r'case (\d+).*?TerraformException: (.+?)\\n', error_message):
+            test_id = match.group(1)
+            error = match.group(2)
+            terraform_errors[test_id] = error
+        return terraform_errors
+
+    def add_terraform_error_results(self, testrun_id, test_id, terraform_error):
+        """Add results for Terraform errors"""
+        status_id = '8'  # Update status_id for Terraform errors
+        comment = "Terraform Exception: {}".format(terraform_error)  # Modify comment to reflect Terraform error
+        self.client.send_post(
+            'add_result_for_case/{}/{}'.format(testrun_id, test_id),
+            {'status_id': status_id, 'comment': comment}
+        )
+
 
     # plugin
 
-    def add_result(
-        self,
-        test_ids,
-        status,
-        comment="",
-        defects=None,
-        duration=0,
-        test_parametrize=None,
-    ):
+    def add_result(self, test_ids, status, comment='', defects=None, duration=0, test_parametrize=None):
         """
         Add a new result to results dict to be submitted at the end.
 
@@ -382,20 +333,26 @@ class PyTestRailPlugin(object):
         :param duration: Time it took to run just the test.
         """
         for test_id in test_ids:
+            # Convert comment to string if it's not already
+            if not isinstance(comment, str):
+                comment = str(comment)
+
+            # Update status code from 5 to 6 for Terraform errors
+            if status == 5 and "TerraformException" in comment:
+                status = 8
+
             data = {
-                "case_id": test_id,
-                "status_id": status,
-                "comment": comment,
-                "duration": duration,
-                "defects": defects,
-                "test_parametrize": test_parametrize,
+                'case_id': test_id,
+                'status_id': status,
+                'comment': comment,
+                'duration': duration,
+                'defects': defects,
+                'test_parametrize': test_parametrize
             }
             self.results.append(data)
-            logger.info(
-                "Added result for case {}: status={}, comment={}, defects={}, duration={}, test_parametrize={}".format(
-                    test_id, status, comment, defects, duration, test_parametrize
-                )
-            )
+            logger.info("Added result for case {}: status={}, comment={}, defects={}, duration={}, test_parametrize={}".format(
+                test_id, status, comment, defects, duration, test_parametrize))
+
 
     def add_error_results(self, testrun_id, invalid_test_ids, error):
         """
@@ -406,37 +363,25 @@ class PyTestRailPlugin(object):
         :param error: Error message.
         """
         # Log the error message and invalid test case IDs
-        logger.error(
-            '[{}] Info: Testcases not published for the following reason: "{}"'.format(
-                TESTRAIL_PREFIX, error
-            )
-        )
-        logger.error(
-            "[{}] Invalid test case IDs: {}".format(TESTRAIL_PREFIX, invalid_test_ids)
-        )
+        logger.error('[{}] Info: Testcases not published for the following reason: "{}"'.format(TESTRAIL_PREFIX, error))
+        logger.error('[{}] Invalid test case IDs: {}'.format(TESTRAIL_PREFIX, invalid_test_ids))
 
         # Remove the leading "C" character from invalid test case IDs if the first character is "C"
-        invalid_test_ids = [
-            id[1:] if id.startswith("C") else id for id in invalid_test_ids
-        ]
-        valid_results = [
-            result
-            for result in self.results
-            if result["case_id"] not in invalid_test_ids
-        ]
-        data = {"results": []}
+        invalid_test_ids = [id[1:] if id.startswith('C') else id for id in invalid_test_ids]
+        valid_results = [result for result in self.results if result['case_id'] not in invalid_test_ids]
+        data = {'results': []}
         for result in valid_results:
             entry = {
-                "case_id": result["case_id"],
-                "status_id": TESTRAIL_TEST_STATUS["failed"],
-                "comment": error,
-                "defects": "",
+                'case_id': result['case_id'],
+                'status_id': TESTRAIL_TEST_STATUS["failed"],
+                'comment': error,
+                'defects': ''
             }
             # Directly call the TestRail API to add the result to the test run
             response = self.client.send_post(
                 ADD_RESULTS_URL.format(testrun_id),
-                {"results": [entry]},
-                cert_check=self.cert_check,
+                {'results': [entry]},
+                cert_check=self.cert_check
             )
 
             logger.info("Response received for error result: {}".format(response))
@@ -444,15 +389,11 @@ class PyTestRailPlugin(object):
             error_response = self.client.get_error(response)
 
             if error_response:
-                logger.error(
-                    '[{}] Error adding result for case {}: "{}"'.format(
-                        TESTRAIL_PREFIX, result["case_id"], error_response
-                    )
-                )
+                logger.error('[{}] Error adding result for case {}: "{}"'.format(TESTRAIL_PREFIX, result['case_id'], error_response))
 
     def add_results(self, testrun_id):
         """
-        Add results one by one to improve errors handling.
+        Add results one by one to improve error handling.
 
         :param testrun_id: Id of the testrun to feed
 
@@ -550,56 +491,55 @@ class PyTestRailPlugin(object):
                 entry["elapsed"] = str(duration) + "s"
             data["results"].append(entry)
 
-            response = self.client.send_post(
-                ADD_RESULTS_URL.format(testrun_id), data, cert_check=self.cert_check
-            )
+        # Send the HTTP POST request outside the loop
+        response = self.client.send_post(
+            ADD_RESULTS_URL.format(testrun_id), data, cert_check=self.cert_check
+        )
 
-            logger.info("Response received: {}".format(response))
+        logger.info("Response received: {}".format(response))
 
-            error = self.client.get_error(response)
+        for resp in response:
+            comment = resp.get("comment", "")
+            if "TerraformException" in comment:
+                status_id = resp.get("status_id")
+                self.add_terraform_error_results(testrun_id, status_id, comment)
 
-            if error:
-                return error
+        error = self.client.get_error(resp)
+        if error:
+            logger.error("Error in sending results to TestRail. Status code: {}".format(resp.status_code))
+            error = self.client.get_error(resp)
+            return error
 
-    def create_test_run(
-        self,
-        assign_user_id,
-        project_id,
-        suite_id,
-        include_all,
-        testrun_name,
-        tr_keys,
-        milestone_id,
-        description="",
-    ):
+    def create_test_run(self, assign_user_id, project_id, suite_id, include_all,
+                        testrun_name, tr_keys, milestone_id, description=''):
         """
         Create testrun with ids collected from markers.
 
         :param tr_keys: collected testrail ids.
         """
         data = {
-            "suite_id": suite_id,
-            "name": testrun_name,
-            "description": description,
-            "assignedto_id": assign_user_id,
-            "include_all": include_all,
-            "case_ids": tr_keys,
-            "milestone_id": milestone_id,
+            'suite_id': suite_id,
+            'name': testrun_name,
+            'description': description,
+            'assignedto_id': assign_user_id,
+            'include_all': include_all,
+            'case_ids': tr_keys,
+            'milestone_id': milestone_id
         }
 
         response = self.client.send_post(
-            ADD_TESTRUN_URL.format(project_id), data, cert_check=self.cert_check
+            ADD_TESTRUN_URL.format(project_id),
+            data,
+            cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
             print('[{}] Failed to create testrun: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            self.testrun_id = response["id"]
-            print(
-                '[{}] New testrun created with name "{}" and ID={}'.format(
-                    TESTRAIL_PREFIX, testrun_name, self.testrun_id
-                )
-            )
+            self.testrun_id = response['id']
+            print('[{}] New testrun created with name "{}" and ID={}'.format(TESTRAIL_PREFIX,
+                                                                             testrun_name,
+                                                                             self.testrun_id))
 
     def close_test_run(self, testrun_id):
         """
@@ -607,17 +547,15 @@ class PyTestRailPlugin(object):
 
         """
         response = self.client.send_post(
-            CLOSE_TESTRUN_URL.format(testrun_id), data={}, cert_check=self.cert_check
+            CLOSE_TESTRUN_URL.format(testrun_id),
+            data={},
+            cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
             print('[{}] Failed to close test run: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            print(
-                "[{}] Test run with ID={} was closed".format(
-                    TESTRAIL_PREFIX, self.testrun_id
-                )
-            )
+            print('[{}] Test run with ID={} was closed'.format(TESTRAIL_PREFIX, self.testrun_id))
 
     def close_test_plan(self, testplan_id):
         """
@@ -625,17 +563,15 @@ class PyTestRailPlugin(object):
 
         """
         response = self.client.send_post(
-            CLOSE_TESTPLAN_URL.format(testplan_id), data={}, cert_check=self.cert_check
+            CLOSE_TESTPLAN_URL.format(testplan_id),
+            data={},
+            cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
             print('[{}] Failed to close test plan: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            print(
-                "[{}] Test plan with ID={} was closed".format(
-                    TESTRAIL_PREFIX, self.testplan_id
-                )
-            )
+            print('[{}] Test plan with ID={} was closed'.format(TESTRAIL_PREFIX, self.testplan_id))
 
     def is_testrun_available(self):
         """
@@ -644,16 +580,15 @@ class PyTestRailPlugin(object):
         :return: True if testrun exists AND is open
         """
         response = self.client.send_get(
-            GET_TESTRUN_URL.format(self.testrun_id), cert_check=self.cert_check
+            GET_TESTRUN_URL.format(self.testrun_id),
+            cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
-            print(
-                '[{}] Failed to retrieve testrun: "{}"'.format(TESTRAIL_PREFIX, error)
-            )
+            print('[{}] Failed to retrieve testrun: "{}"'.format(TESTRAIL_PREFIX, error))
             return False
 
-        return response["is_completed"] is False
+        return response['is_completed'] is False
 
     def is_testplan_available(self):
         """
@@ -662,16 +597,15 @@ class PyTestRailPlugin(object):
         :return: True if testplan exists AND is open
         """
         response = self.client.send_get(
-            GET_TESTPLAN_URL.format(self.testplan_id), cert_check=self.cert_check
+            GET_TESTPLAN_URL.format(self.testplan_id),
+            cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
-            print(
-                '[{}] Failed to retrieve testplan: "{}"'.format(TESTRAIL_PREFIX, error)
-            )
+            print('[{}] Failed to retrieve testplan: "{}"'.format(TESTRAIL_PREFIX, error))
             return False
 
-        return response["is_completed"] is False
+        return response['is_completed'] is False
 
     def get_available_testruns(self, plan_id):
         """
@@ -680,18 +614,17 @@ class PyTestRailPlugin(object):
         """
         testruns_list = []
         response = self.client.send_get(
-            GET_TESTPLAN_URL.format(plan_id), cert_check=self.cert_check
+            GET_TESTPLAN_URL.format(plan_id),
+            cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
-            print(
-                '[{}] Failed to retrieve testplan: "{}"'.format(TESTRAIL_PREFIX, error)
-            )
+            print('[{}] Failed to retrieve testplan: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            for entry in response["entries"]:
-                for run in entry["runs"]:
-                    if not run["is_completed"]:
-                        testruns_list.append(run["id"])
+            for entry in response['entries']:
+                for run in entry['runs']:
+                    if not run['is_completed']:
+                        testruns_list.append(run['id'])
         return testruns_list
 
     def get_tests(self, run_id):
@@ -700,7 +633,8 @@ class PyTestRailPlugin(object):
 
         """
         response = self.client.send_get(
-            GET_TESTS_URL.format(run_id), cert_check=self.cert_check
+            GET_TESTS_URL.format(run_id),
+            cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -13,7 +13,7 @@ TESTRAIL_TEST_STATUS = {
     "blocked": 2,
     "untested": 3,
     "retest": 4,
-    "failed": 5
+    "failed": 5,
 }
 
 PYTEST_TO_TESTRAIL_STATUS = {
@@ -22,34 +22,36 @@ PYTEST_TO_TESTRAIL_STATUS = {
     "skipped": TESTRAIL_TEST_STATUS["blocked"],
 }
 
-DT_FORMAT = '%d-%m-%Y %H:%M:%S'
+DT_FORMAT = "%d-%m-%Y %H:%M:%S"
 
-TESTRAIL_PREFIX = 'testrail'
-TESTRAIL_DEFECTS_PREFIX = 'testrail_defects'
-ADD_RESULTS_URL = 'add_results_for_cases/{}'
-ADD_TESTRUN_URL = 'add_run/{}'
-CLOSE_TESTRUN_URL = 'close_run/{}'
-CLOSE_TESTPLAN_URL = 'close_plan/{}'
-GET_TESTRUN_URL = 'get_run/{}'
-GET_TESTPLAN_URL = 'get_plan/{}'
-GET_TESTS_URL = 'get_tests/{}'
+TESTRAIL_PREFIX = "testrail"
+TESTRAIL_DEFECTS_PREFIX = "testrail_defects"
+ADD_RESULTS_URL = "add_results_for_cases/{}"
+ADD_TESTRUN_URL = "add_run/{}"
+CLOSE_TESTRUN_URL = "close_run/{}"
+CLOSE_TESTPLAN_URL = "close_plan/{}"
+GET_TESTRUN_URL = "get_run/{}"
+GET_TESTPLAN_URL = "get_plan/{}"
+GET_TESTS_URL = "get_tests/{}"
 
 COMMENT_SIZE_LIMIT = 4000
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
 class DeprecatedTestDecorator(DeprecationWarning):
     pass
 
 
-warnings.simplefilter(action='once', category=DeprecatedTestDecorator, lineno=0)
+warnings.simplefilter(action="once", category=DeprecatedTestDecorator, lineno=0)
 
 
 class pytestrail(object):
-    '''
+    """
     An alternative to using the testrail function as a decorator for test cases, since py.test may confuse it as a test
     function since it has the 'test' prefix
-    '''
+    """
 
     @staticmethod
     def case(*ids):
@@ -65,12 +67,12 @@ class pytestrail(object):
     @staticmethod
     def defect(*defect_ids):
         """
-                Decorator to mark defects with defect ids.
+        Decorator to mark defects with defect ids.
 
-                ie. @pytestrail.defect('PF-513', 'BR-3255')
+        ie. @pytestrail.defect('PF-513', 'BR-3255')
 
-                :return pytest.mark:
-                """
+        :return pytest.mark:
+        """
         return pytest.mark.testrail_defects(defect_ids=defect_ids)
 
 
@@ -82,8 +84,10 @@ def testrail(*ids):
 
     :return pytest.mark:
     """
-    deprecation_msg = ('pytest_testrail: the @testrail decorator is deprecated and will be removed. Please use the '
-                       '@pytestrail.case decorator instead.')
+    deprecation_msg = (
+        "pytest_testrail: the @testrail decorator is deprecated and will be removed. Please use the "
+        "@pytestrail.case decorator instead."
+    )
     warnings.warn(deprecation_msg, DeprecatedTestDecorator)
     return pytestrail.case(*ids)
 
@@ -101,7 +105,7 @@ def get_test_outcome(outcome):
 def testrun_name():
     """Returns testrun name with timestamp"""
     now = datetime.utcnow()
-    return 'Automated Run {}'.format(now.strftime(DT_FORMAT))
+    return "Automated Run {}".format(now.strftime(DT_FORMAT))
 
 
 def clean_test_ids(test_ids):
@@ -111,17 +115,23 @@ def clean_test_ids(test_ids):
     :param list test_ids: list of test_ids.
     :return list ints: contains list of test_ids as ints.
     """
-    return [int(re.search('(?P<test_id>[0-9]+$)', test_id).groupdict().get('test_id')) for test_id in test_ids]
+    return [
+        int(re.search("(?P<test_id>[0-9]+$)", test_id).groupdict().get("test_id"))
+        for test_id in test_ids
+    ]
 
 
 def clean_test_defects(defect_ids):
     """
-        Clean pytest marker containing testrail defects ids.
+    Clean pytest marker containing testrail defects ids.
 
-        :param list defect_ids: list of defect_ids.
-        :return list ints: contains list of defect_ids as ints.
-        """
-    return [(re.search('(?P<defect_id>.*)', defect_id).groupdict().get('defect_id')) for defect_id in defect_ids]
+    :param list defect_ids: list of defect_ids.
+    :return list ints: contains list of defect_ids as ints.
+    """
+    return [
+        (re.search("(?P<defect_id>.*)", defect_id).groupdict().get("defect_id"))
+        for defect_id in defect_ids
+    ]
 
 
 def get_testrail_keys(items):
@@ -133,17 +143,33 @@ def get_testrail_keys(items):
                 (
                     item,
                     clean_test_ids(
-                        item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get('ids')
-                    )
+                        item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get("ids")
+                    ),
                 )
             )
     return testcaseids
 
 
 class PyTestRailPlugin(object):
-    def __init__(self, client, assign_user_id, project_id, suite_id, include_all, cert_check, tr_name,
-                 tr_description='', run_id=0, plan_id=0, version='', close_on_complete=False,
-                 publish_blocked=True, skip_missing=False, milestone_id=None, custom_comment=None):
+    def __init__(
+        self,
+        client,
+        assign_user_id,
+        project_id,
+        suite_id,
+        include_all,
+        cert_check,
+        tr_name,
+        tr_description="",
+        run_id=0,
+        plan_id=0,
+        version="",
+        close_on_complete=False,
+        publish_blocked=True,
+        skip_missing=False,
+        milestone_id=None,
+        custom_comment=None,
+    ):
         self.assign_user_id = assign_user_id
         self.cert_check = cert_check
         self.client = client
@@ -165,14 +191,14 @@ class PyTestRailPlugin(object):
     # pytest hooks
 
     def pytest_report_header(self, config, startdir):
-        """ Add extra-info in header """
-        message = 'pytest-testrail: '
+        """Add extra-info in header"""
+        message = "pytest-testrail: "
         if self.testplan_id:
-            message += 'existing testplan #{} selected'.format(self.testplan_id)
+            message += "existing testplan #{} selected".format(self.testplan_id)
         elif self.testrun_id:
-            message += 'existing testrun #{} selected'.format(self.testrun_id)
+            message += "existing testrun #{} selected".format(self.testrun_id)
         else:
-            message += 'a new testrun will be created'
+            message += "a new testrun will be created"
         return message
 
     @pytest.hookimpl(trylast=True)
@@ -186,11 +212,11 @@ class PyTestRailPlugin(object):
             self.testplan_id = 0
             if self.skip_missing:
                 tests_list = [
-                    test.get('case_id') for test in self.get_tests(self.testrun_id)
+                    test.get("case_id") for test in self.get_tests(self.testrun_id)
                 ]
                 for item, case_id in items_with_tr_keys:
                     if not set(case_id).intersection(set(tests_list)):
-                        mark = pytest.mark.skip('Test is not present in testrun.')
+                        mark = pytest.mark.skip("Test is not present in testrun.")
                         item.add_marker(mark)
         else:
             if self.testrun_name is None:
@@ -204,27 +230,29 @@ class PyTestRailPlugin(object):
                 self.testrun_name,
                 tr_keys,
                 self.milestone_id,
-                self.testrun_description
+                self.testrun_description,
             )
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True)
     def pytest_runtest_makereport(self, item, call):
-        """ Collect result and associated testcases (TestRail) of an execution """
+        """Collect result and associated testcases (TestRail) of an execution"""
         outcome = yield
         rep = outcome.get_result()
         defectids = None
-        if 'callspec' in dir(item):
+        if "callspec" in dir(item):
             test_parametrize = item.callspec.params
         else:
             test_parametrize = None
         comment = rep.longrepr
         if item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX):
-            defectids = item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX).kwargs.get('defect_ids')
+            defectids = item.get_closest_marker(TESTRAIL_DEFECTS_PREFIX).kwargs.get(
+                "defect_ids"
+            )
         if item.get_closest_marker(TESTRAIL_PREFIX):
-            testcaseids = item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get('ids')
-            if rep.when in ['setup', 'call'] and testcaseids:
+            testcaseids = item.get_closest_marker(TESTRAIL_PREFIX).kwargs.get("ids")
+            if rep.when in ["setup", "call"] and testcaseids:
                 # Check if the test case has already been processed
-                if not getattr(item, 'testrail_processed', False):
+                if not getattr(item, "testrail_processed", False):
                     # Mark the test case as processed
                     item.testrail_processed = True
                     if defectids:
@@ -233,8 +261,11 @@ class PyTestRailPlugin(object):
                             get_test_outcome(outcome.get_result().outcome),
                             comment=comment,
                             duration=rep.duration,
-                            defects=str(clean_test_defects(defectids)).replace('[', '').replace(']', '').replace("'", ''),
-                            test_parametrize=test_parametrize
+                            defects=str(clean_test_defects(defectids))
+                            .replace("[", "")
+                            .replace("]", "")
+                            .replace("'", ""),
+                            test_parametrize=test_parametrize,
                         )
                     else:
                         self.add_result(
@@ -242,56 +273,104 @@ class PyTestRailPlugin(object):
                             get_test_outcome(outcome.get_result().outcome),
                             comment=comment,
                             duration=rep.duration,
-                            test_parametrize=test_parametrize
+                            test_parametrize=test_parametrize,
                         )
 
     def pytest_sessionfinish(self, session, exitstatus):
         """Publish results in TestRail"""
-        print('[{}] Start publishing'.format(TESTRAIL_PREFIX))
+        print("[{}] Start publishing".format(TESTRAIL_PREFIX))
         if self.results:
-            tests_list = [str(result['case_id']) for result in self.results]
-            print('[{}] Testcases to publish: {}'.format(TESTRAIL_PREFIX, ', '.join(tests_list)))
+            tests_list = [str(result["case_id"]) for result in self.results]
+            print(
+                "[{}] Testcases to publish: {}".format(
+                    TESTRAIL_PREFIX, ", ".join(tests_list)
+                )
+            )
             if self.testrun_id:
                 error = self.add_results(self.testrun_id)  # Check for errors
-                if error and 'results cannot be empty but no valid tests or cases found' in error:
-                    print('[{}] No valid test results to publish'.format(TESTRAIL_PREFIX))
-                    raise Exception('No valid test results to publish in TestRail')
+                if (
+                    error
+                    and "results cannot be empty but no valid tests or cases found"
+                    in error
+                ):
+                    print(
+                        "[{}] No valid test results to publish".format(TESTRAIL_PREFIX)
+                    )
+                    raise Exception("No valid test results to publish in TestRail")
                 elif error:
-                    error_message_parts = error.split(')')
-                    invalid_test_ids = [part.split('case ')[1].split(' ')[0] for part in error_message_parts if 'case' in part]
-                    valid_results = [result for result in self.results if result['case_id'] not in invalid_test_ids]
+                    error_message_parts = error.split(")")
+                    invalid_test_ids = [
+                        part.split("case ")[1].split(" ")[0]
+                        for part in error_message_parts
+                        if "case" in part
+                    ]
+                    valid_results = [
+                        result
+                        for result in self.results
+                        if result["case_id"] not in invalid_test_ids
+                    ]
                     for invalid_test_id in invalid_test_ids:
-                        self.add_error_results(self.testrun_id, [invalid_test_id], error)
+                        self.add_error_results(
+                            self.testrun_id, [invalid_test_id], error
+                        )
             elif self.testplan_id:
                 testruns = self.get_available_testruns(self.testplan_id)
-                print('[{}] Testruns to update: {}'.format(TESTRAIL_PREFIX, ', '.join([str(elt) for elt in testruns])))
+                print(
+                    "[{}] Testruns to update: {}".format(
+                        TESTRAIL_PREFIX, ", ".join([str(elt) for elt in testruns])
+                    )
+                )
                 for testrun_id in testruns:
                     error = self.add_results(testrun_id)  # Check for errors
-                    if error and 'results cannot be empty but no valid tests or cases found' in error:
-                        print('[{}] No valid test results to publish for testrun {}'.format(TESTRAIL_PREFIX, testrun_id))
-                        raise Exception('No valid test results to publish in TestRail')
+                    if (
+                        error
+                        and "results cannot be empty but no valid tests or cases found"
+                        in error
+                    ):
+                        print(
+                            "[{}] No valid test results to publish for testrun {}".format(
+                                TESTRAIL_PREFIX, testrun_id
+                            )
+                        )
+                        raise Exception("No valid test results to publish in TestRail")
                     elif error:
-                        error_message_parts = error.split(')')
-                        invalid_test_ids = [part.split('case ')[1].split(' ')[0] for part in error_message_parts if 'case' in part]
-                        valid_results = [result for result in self.results if result['case_id'] not in invalid_test_ids]
+                        error_message_parts = error.split(")")
+                        invalid_test_ids = [
+                            part.split("case ")[1].split(" ")[0]
+                            for part in error_message_parts
+                            if "case" in part
+                        ]
+                        valid_results = [
+                            result
+                            for result in self.results
+                            if result["case_id"] not in invalid_test_ids
+                        ]
                         for invalid_test_id in invalid_test_ids:
                             self.add_error_results(testrun_id, [invalid_test_id], error)
             else:
-                print('[{}] No data published'.format(TESTRAIL_PREFIX))
+                print("[{}] No data published".format(TESTRAIL_PREFIX))
 
             if self.close_on_complete and self.testrun_id:
                 self.close_test_run(self.testrun_id)
             elif self.close_on_complete and self.testplan_id:
                 self.close_test_plan(self.testplan_id)
         else:
-            print('[{}] No test results to publish'.format(TESTRAIL_PREFIX))
+            print("[{}] No test results to publish".format(TESTRAIL_PREFIX))
             # Gracefully handle the scenario where there are no test results to publish
-            raise Exception('No test results to publish in TestRail')
-        print('[{}] End publishing'.format(TESTRAIL_PREFIX))
+            raise Exception("No test results to publish in TestRail")
+        print("[{}] End publishing".format(TESTRAIL_PREFIX))
 
     # plugin
 
-    def add_result(self, test_ids, status, comment='', defects=None, duration=0, test_parametrize=None):
+    def add_result(
+        self,
+        test_ids,
+        status,
+        comment="",
+        defects=None,
+        duration=0,
+        test_parametrize=None,
+    ):
         """
         Add a new result to results dict to be submitted at the end.
 
@@ -304,16 +383,19 @@ class PyTestRailPlugin(object):
         """
         for test_id in test_ids:
             data = {
-                'case_id': test_id,
-                'status_id': status,
-                'comment': comment,
-                'duration': duration,
-                'defects': defects,
-                'test_parametrize': test_parametrize
+                "case_id": test_id,
+                "status_id": status,
+                "comment": comment,
+                "duration": duration,
+                "defects": defects,
+                "test_parametrize": test_parametrize,
             }
             self.results.append(data)
-            logger.info("Added result for case {}: status={}, comment={}, defects={}, duration={}, test_parametrize={}".format(
-                test_id, status, comment, defects, duration, test_parametrize))
+            logger.info(
+                "Added result for case {}: status={}, comment={}, defects={}, duration={}, test_parametrize={}".format(
+                    test_id, status, comment, defects, duration, test_parametrize
+                )
+            )
 
     def add_error_results(self, testrun_id, invalid_test_ids, error):
         """
@@ -324,25 +406,37 @@ class PyTestRailPlugin(object):
         :param error: Error message.
         """
         # Log the error message and invalid test case IDs
-        logger.error('[{}] Info: Testcases not published for the following reason: "{}"'.format(TESTRAIL_PREFIX, error))
-        logger.error('[{}] Invalid test case IDs: {}'.format(TESTRAIL_PREFIX, invalid_test_ids))
+        logger.error(
+            '[{}] Info: Testcases not published for the following reason: "{}"'.format(
+                TESTRAIL_PREFIX, error
+            )
+        )
+        logger.error(
+            "[{}] Invalid test case IDs: {}".format(TESTRAIL_PREFIX, invalid_test_ids)
+        )
 
         # Remove the leading "C" character from invalid test case IDs if the first character is "C"
-        invalid_test_ids = [id[1:] if id.startswith('C') else id for id in invalid_test_ids]
-        valid_results = [result for result in self.results if result['case_id'] not in invalid_test_ids]
-        data = {'results': []}
+        invalid_test_ids = [
+            id[1:] if id.startswith("C") else id for id in invalid_test_ids
+        ]
+        valid_results = [
+            result
+            for result in self.results
+            if result["case_id"] not in invalid_test_ids
+        ]
+        data = {"results": []}
         for result in valid_results:
             entry = {
-                'case_id': result['case_id'],
-                'status_id': TESTRAIL_TEST_STATUS["failed"],
-                'comment': error,
-                'defects': ''
+                "case_id": result["case_id"],
+                "status_id": TESTRAIL_TEST_STATUS["failed"],
+                "comment": error,
+                "defects": "",
             }
             # Directly call the TestRail API to add the result to the test run
             response = self.client.send_post(
                 ADD_RESULTS_URL.format(testrun_id),
-                {'results': [entry]},
-                cert_check=self.cert_check
+                {"results": [entry]},
+                cert_check=self.cert_check,
             )
 
             logger.info("Response received for error result: {}".format(response))
@@ -350,7 +444,11 @@ class PyTestRailPlugin(object):
             error_response = self.client.get_error(response)
 
             if error_response:
-                logger.error('[{}] Error adding result for case {}: "{}"'.format(TESTRAIL_PREFIX, result['case_id'], error_response))
+                logger.error(
+                    '[{}] Error adding result for case {}: "{}"'.format(
+                        TESTRAIL_PREFIX, result["case_id"], error_response
+                    )
+                )
 
     def add_results(self, testrun_id):
         """
@@ -365,59 +463,95 @@ class PyTestRailPlugin(object):
         except NameError:
             converter = lambda s, c: str(bytes(s, "utf-8"), c)
         # Results are sorted by 'case_id' and by 'status_id' (worst result at the end)
-        self.results.sort(key=itemgetter('case_id'))
+        self.results.sort(key=itemgetter("case_id"))
 
         # Manage case of "blocked" testcases
         if self.publish_blocked is False:
-            logger.info('[{}] Option "Don\'t publish blocked testcases" activated'.format(TESTRAIL_PREFIX))
+            logger.info(
+                '[{}] Option "Don\'t publish blocked testcases" activated'.format(
+                    TESTRAIL_PREFIX
+                )
+            )
             blocked_tests_list = [
-                test.get('case_id') for test in self.get_tests(testrun_id)
-                if test.get('status_id') == TESTRAIL_TEST_STATUS["blocked"]
+                test.get("case_id")
+                for test in self.get_tests(testrun_id)
+                if test.get("status_id") == TESTRAIL_TEST_STATUS["blocked"]
             ]
-            logger.info('[{}] Blocked testcases excluded: {}'.format(TESTRAIL_PREFIX,
-                                                            ', '.join(str(elt) for elt in blocked_tests_list)))
-            self.results = [result for result in self.results if result.get('case_id') not in blocked_tests_list]
+            logger.info(
+                "[{}] Blocked testcases excluded: {}".format(
+                    TESTRAIL_PREFIX, ", ".join(str(elt) for elt in blocked_tests_list)
+                )
+            )
+            self.results = [
+                result
+                for result in self.results
+                if result.get("case_id") not in blocked_tests_list
+            ]
 
         # prompt enabling include all test cases from test suite when creating test run
         if self.include_all:
-            logger.info('[{}] Option "Include all testcases from test suite for test run" activated'.format(TESTRAIL_PREFIX))
+            logger.info(
+                '[{}] Option "Include all testcases from test suite for test run" activated'.format(
+                    TESTRAIL_PREFIX
+                )
+            )
 
         # Publish results
-        data = {'results': []}
+        data = {"results": []}
         for result in self.results:
-            entry = {'status_id': result['status_id'], 'case_id': result['case_id'], 'defects': result['defects']}
+            entry = {
+                "status_id": result["status_id"],
+                "case_id": result["case_id"],
+                "defects": result["defects"],
+            }
             if self.version:
-                entry['version'] = self.version
-            comment = result.get('comment', '')
-            test_parametrize = result.get('test_parametrize', '')
-            entry['comment'] = u''
+                entry["version"] = self.version
+            comment = result.get("comment", "")
+            test_parametrize = result.get("test_parametrize", "")
+            entry["comment"] = ""
             if test_parametrize:
-                entry['comment'] += u"# Test parametrize: #\n"
-                entry['comment'] += str(test_parametrize) + u'\n\n'
+                entry["comment"] += "# Test parametrize: #\n"
+                entry["comment"] += str(test_parametrize) + "\n\n"
             if comment:
                 if self.custom_comment:
-                    entry['comment'] += self.custom_comment + '\n'
+                    entry["comment"] += self.custom_comment + "\n"
                     # Indent text to avoid string formatting by TestRail. Limit size of comment.
-                    entry['comment'] += u"# Pytest result: #\n"
-                    entry['comment'] += u'Log truncated\n...\n' if len(str(comment)) > COMMENT_SIZE_LIMIT else u''
-                    entry['comment'] += u"    " + converter(str(comment), "utf-8")[-COMMENT_SIZE_LIMIT:].replace('\n', '\n    ') # noqa
+                    entry["comment"] += "# Pytest result: #\n"
+                    entry["comment"] += (
+                        "Log truncated\n...\n"
+                        if len(str(comment)) > COMMENT_SIZE_LIMIT
+                        else ""
+                    )
+                    entry["comment"] += "    " + converter(str(comment), "utf-8")[
+                        -COMMENT_SIZE_LIMIT:
+                    ].replace(
+                        "\n", "\n    "
+                    )  # noqa
                 else:
                     # Indent text to avoid string formatting by TestRail. Limit size of comment.
-                    entry['comment'] += u"# Pytest result: #\n"
-                    entry['comment'] += u'Log truncated\n...\n' if len(str(comment)) > COMMENT_SIZE_LIMIT else u''
-                    entry['comment'] += u"    " + converter(str(comment), "utf-8")[-COMMENT_SIZE_LIMIT:].replace('\n', '\n    ') # noqa
-            elif comment == '':
-                entry['comment'] = self.custom_comment
-            duration = result.get('duration')
+                    entry["comment"] += "# Pytest result: #\n"
+                    entry["comment"] += (
+                        "Log truncated\n...\n"
+                        if len(str(comment)) > COMMENT_SIZE_LIMIT
+                        else ""
+                    )
+                    entry["comment"] += "    " + converter(str(comment), "utf-8")[
+                        -COMMENT_SIZE_LIMIT:
+                    ].replace(
+                        "\n", "\n    "
+                    )  # noqa
+            elif comment == "":
+                entry["comment"] = self.custom_comment
+            duration = result.get("duration")
             if duration:
-                duration = 1 if (duration < 1) else int(round(duration))  # TestRail API doesn't manage milliseconds
-                entry['elapsed'] = str(duration) + 's'
-            data['results'].append(entry)
+                duration = (
+                    1 if (duration < 1) else int(round(duration))
+                )  # TestRail API doesn't manage milliseconds
+                entry["elapsed"] = str(duration) + "s"
+            data["results"].append(entry)
 
             response = self.client.send_post(
-                ADD_RESULTS_URL.format(testrun_id),
-                data,
-                cert_check=self.cert_check
+                ADD_RESULTS_URL.format(testrun_id), data, cert_check=self.cert_check
             )
 
             logger.info("Response received: {}".format(response))
@@ -427,37 +561,45 @@ class PyTestRailPlugin(object):
             if error:
                 return error
 
-
-    def create_test_run(self, assign_user_id, project_id, suite_id, include_all,
-                        testrun_name, tr_keys, milestone_id, description=''):
+    def create_test_run(
+        self,
+        assign_user_id,
+        project_id,
+        suite_id,
+        include_all,
+        testrun_name,
+        tr_keys,
+        milestone_id,
+        description="",
+    ):
         """
         Create testrun with ids collected from markers.
 
         :param tr_keys: collected testrail ids.
         """
         data = {
-            'suite_id': suite_id,
-            'name': testrun_name,
-            'description': description,
-            'assignedto_id': assign_user_id,
-            'include_all': include_all,
-            'case_ids': tr_keys,
-            'milestone_id': milestone_id
+            "suite_id": suite_id,
+            "name": testrun_name,
+            "description": description,
+            "assignedto_id": assign_user_id,
+            "include_all": include_all,
+            "case_ids": tr_keys,
+            "milestone_id": milestone_id,
         }
 
         response = self.client.send_post(
-            ADD_TESTRUN_URL.format(project_id),
-            data,
-            cert_check=self.cert_check
+            ADD_TESTRUN_URL.format(project_id), data, cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
             print('[{}] Failed to create testrun: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            self.testrun_id = response['id']
-            print('[{}] New testrun created with name "{}" and ID={}'.format(TESTRAIL_PREFIX,
-                                                                             testrun_name,
-                                                                             self.testrun_id))
+            self.testrun_id = response["id"]
+            print(
+                '[{}] New testrun created with name "{}" and ID={}'.format(
+                    TESTRAIL_PREFIX, testrun_name, self.testrun_id
+                )
+            )
 
     def close_test_run(self, testrun_id):
         """
@@ -465,15 +607,17 @@ class PyTestRailPlugin(object):
 
         """
         response = self.client.send_post(
-            CLOSE_TESTRUN_URL.format(testrun_id),
-            data={},
-            cert_check=self.cert_check
+            CLOSE_TESTRUN_URL.format(testrun_id), data={}, cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
             print('[{}] Failed to close test run: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            print('[{}] Test run with ID={} was closed'.format(TESTRAIL_PREFIX, self.testrun_id))
+            print(
+                "[{}] Test run with ID={} was closed".format(
+                    TESTRAIL_PREFIX, self.testrun_id
+                )
+            )
 
     def close_test_plan(self, testplan_id):
         """
@@ -481,15 +625,17 @@ class PyTestRailPlugin(object):
 
         """
         response = self.client.send_post(
-            CLOSE_TESTPLAN_URL.format(testplan_id),
-            data={},
-            cert_check=self.cert_check
+            CLOSE_TESTPLAN_URL.format(testplan_id), data={}, cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
             print('[{}] Failed to close test plan: "{}"'.format(TESTRAIL_PREFIX, error))
         else:
-            print('[{}] Test plan with ID={} was closed'.format(TESTRAIL_PREFIX, self.testplan_id))
+            print(
+                "[{}] Test plan with ID={} was closed".format(
+                    TESTRAIL_PREFIX, self.testplan_id
+                )
+            )
 
     def is_testrun_available(self):
         """
@@ -498,15 +644,16 @@ class PyTestRailPlugin(object):
         :return: True if testrun exists AND is open
         """
         response = self.client.send_get(
-            GET_TESTRUN_URL.format(self.testrun_id),
-            cert_check=self.cert_check
+            GET_TESTRUN_URL.format(self.testrun_id), cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
-            print('[{}] Failed to retrieve testrun: "{}"'.format(TESTRAIL_PREFIX, error))
+            print(
+                '[{}] Failed to retrieve testrun: "{}"'.format(TESTRAIL_PREFIX, error)
+            )
             return False
 
-        return response['is_completed'] is False
+        return response["is_completed"] is False
 
     def is_testplan_available(self):
         """
@@ -515,15 +662,16 @@ class PyTestRailPlugin(object):
         :return: True if testplan exists AND is open
         """
         response = self.client.send_get(
-            GET_TESTPLAN_URL.format(self.testplan_id),
-            cert_check=self.cert_check
+            GET_TESTPLAN_URL.format(self.testplan_id), cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
-            print('[{}] Failed to retrieve testplan: "{}"'.format(TESTRAIL_PREFIX, error))
+            print(
+                '[{}] Failed to retrieve testplan: "{}"'.format(TESTRAIL_PREFIX, error)
+            )
             return False
 
-        return response['is_completed'] is False
+        return response["is_completed"] is False
 
     def get_available_testruns(self, plan_id):
         """
@@ -532,17 +680,18 @@ class PyTestRailPlugin(object):
         """
         testruns_list = []
         response = self.client.send_get(
-            GET_TESTPLAN_URL.format(plan_id),
-            cert_check=self.cert_check
+            GET_TESTPLAN_URL.format(plan_id), cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:
-            print('[{}] Failed to retrieve testplan: "{}"'.format(TESTRAIL_PREFIX, error))
+            print(
+                '[{}] Failed to retrieve testplan: "{}"'.format(TESTRAIL_PREFIX, error)
+            )
         else:
-            for entry in response['entries']:
-                for run in entry['runs']:
-                    if not run['is_completed']:
-                        testruns_list.append(run['id'])
+            for entry in response["entries"]:
+                for run in entry["runs"]:
+                    if not run["is_completed"]:
+                        testruns_list.append(run["id"])
         return testruns_list
 
     def get_tests(self, run_id):
@@ -551,8 +700,7 @@ class PyTestRailPlugin(object):
 
         """
         response = self.client.send_get(
-            GET_TESTS_URL.format(run_id),
-            cert_check=self.cert_check
+            GET_TESTS_URL.format(run_id), cert_check=self.cert_check
         )
         error = self.client.get_error(response)
         if error:

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -479,6 +479,7 @@ class PyTestRailPlugin(object):
                     self.add_terraform_error_results(testrun_id, status_id, comment)
         error = self.client.get_error(response)
         if error:
+            print('[{}] Info: Testcases not published for following reason: "{}"'.format(TESTRAIL_PREFIX, error))
             return error
 
     def create_test_run(self, assign_user_id, project_id, suite_id, include_all,


### PR DESCRIPTION
Test 1: Terraform Apply Failed, update the testrail report with "Terraform apply Failure" type instead of Generic Error
globalvpc_test failed with Terraform apply issue, on testrail, it's reported as Terraform Failure
https://github.com/AviatrixDev/cloudn/actions/runs/9451131741/job/26031830669 
![Screenshot 2024-06-10 at 10 16 41 AM](https://github.com/jshen-avtx/pytest-testrail/assets/104779602/2c40b58b-1520-41be-9e1f-13ae73b488e8)
Test 2: Suppose case id is not correct, update the testrail report with clear error messages indicating the root cause of wrong case ids, the current behavior is that the pytest-testrail does not handle the error properly and results in the testsuite being "untested"
https://github.com/AviatrixDev/cloudn/actions/runs/9451186702/job/26031963043
```
2024-06-10T15:52:18 ERROR pytest_testrail.plugin [testrail] Info: Testcases not published for the following reason: "Field :results contains one or more invalid results (case C1 unknown or not part of the test run)"
2024-06-10T15:52:18 ERROR pytest_testrail.plugin [testrail] Invalid test case IDs: ['C1']
2024-06-10T15:52:18 DEBUG urllib3.connectionpool Starting new HTTPS connection (1): aviatrix.testrail.io:443
2024-06-10T15:52:18 DEBUG urllib3.connectionpool [https://aviatrix.testrail.io:443](https://aviatrix.testrail.io/) "POST /index.php?/api/v2/add_results_for_cases/22458 HTTP/1.1" 400 109
2024-06-10T15:52:18 INFO pytest_testrail.plugin Response received for error result: ***'error': 'Field :results contains one or more invalid results (case C1 unknown or not part of the test run)'***
2024-06-10T15:52:18 ERROR pytest_testrail.plugin [testrail] Error adding result for case 1: "Field :results contains one or more invalid results (case C1 unknown or not part of the test run)"
2024-06-10T15:52:18 DEBUG urllib3.connectionpool Starting new HTTPS connection (1): aviatrix.testrail.io:443
2024-06-10T15:52:19 DEBUG urllib3.connectionpool [https://aviatrix.testrail.io:443](https://aviatrix.testrail.io/) "POST /index.php?/api/v2/add_results_for_cases/22458 HTTP/1.1" 400 109
2024-06-10T15:52:19 INFO pytest_testrail.plugin Response received for error result: ***'error': 'Field :results contains one or more invalid results (case C2 unknown or not part of the test run)'***
2024-06-10T15:52:19 ERROR pytest_testrail.plugin [testrail] Error adding result for case 2: "Field :results contains one or more invalid results (case C2 unknown or not part of the test run)"
2024-06-10T15:52:19 DEBUG urllib3.connectionpool Starting new HTTPS connection (1): aviatrix.testrail.io:443
2024-06-10T15:52:19 DEBUG urllib3.connectionpool [https://aviatrix.testrail.io:443](https://aviatrix.testrail.io/) "POST /index.php?/api/v2/add_results_for_cases/22458 HTTP/1.1" 400 76
2024-06-10T15:52:19 INFO pytest_testrail.plugin Response received for error result: ***'error': 'Field :results cannot be empty but no valid tests or cases found'***
2024-06-10T15:52:19 ERROR pytest_testrail.plugin [testrail] Error adding result for case 949024933: "Field :results cannot be empty but no valid tests or cases found"
[testrail] End publishing

```
![Screenshot 2024-06-10 at 10 22 43 AM](https://github.com/jshen-avtx/pytest-testrail/assets/104779602/67e4af30-7671-4099-bc1e-c8dcec063abc)

![Screenshot 2024-06-10 at 10 32 22 AM](https://github.com/jshen-avtx/pytest-testrail/assets/104779602/80a847de-c6b6-4dfe-baee-4a1f339ec93b)
![Screenshot 2024-06-10 at 10 32 03 AM](https://github.com/jshen-avtx/pytest-testrail/assets/104779602/d3facc66-19c2-4399-91a1-8e4d68a54d4f)

TBD:
1. A CI to do basic validation in this repo (Ideally we should run ut all the time per pr, but looks the python code here does not even pass pylint/black?)
2. Adding more tests for the two manual cases mentioned above in UT
3. Test Coverage, there's no metrics for that now, but I assume it's fairly low, since it already failed three manual cases AFAIK
4. 
Update on bac009ae6de0d2daac9113c9b5acfd63d94baec9:
For testcase mismatch scenario, not only failed the GHA job, but also update meaningful error so that when the testcase id does not match, it would update the working testcases with an valid error to notify the user to fix the case id issue.

https://github.com/AviatrixDev/cloudn/actions/runs/9456190468/job/26047986741
https://aviatrix.testrail.io/index.php?/tests/view/7216680&group_by=cases:section_id&group_order=asc&group_id=7710
![Screenshot 2024-06-10 at 3 41 13 PM](https://github.com/jshen-avtx/pytest-testrail/assets/104779602/c5ebc71f-f4af-4c63-8bbf-5bb18c9ba84c)

